### PR TITLE
진행도 표시 추가

### DIFF
--- a/apps/service/src/components/Progress.tsx
+++ b/apps/service/src/components/Progress.tsx
@@ -1,0 +1,13 @@
+export const Progress = ({
+  current,
+  total
+}: {
+  current: number
+  total: number
+}) => {
+  return (
+    <div>
+      {current}/{total}
+    </div>
+  )
+}

--- a/apps/service/src/components/TypeSlots.tsx
+++ b/apps/service/src/components/TypeSlots.tsx
@@ -3,7 +3,6 @@ import { TypeArea } from "./TypeArea"
 import { useTypingStatus } from "./TypingStatusProvider"
 
 import { Progress } from "@/components/Progress"
-import clsx from "clsx"
 import { useEffect, useRef, useState } from "react"
 
 export const TypeSlots = ({
@@ -41,7 +40,7 @@ export const TypeSlots = ({
     >
       <div className='mx-auto w-full max-w-4xl'>
         <RecordProvider target={quote}>
-          <div className={clsx("flex items-center justify-between")}>
+          <div className='flex items-center justify-between'>
             <Record target={quote} />
             <Progress current={index + 1} total={quotes.length} />
           </div>

--- a/apps/service/src/components/TypeSlots.tsx
+++ b/apps/service/src/components/TypeSlots.tsx
@@ -2,6 +2,8 @@ import { Record, RecordProvider } from "./Record"
 import { TypeArea } from "./TypeArea"
 import { useTypingStatus } from "./TypingStatusProvider"
 
+import { Progress } from "@/components/Progress"
+import clsx from "clsx"
 import { useEffect, useRef, useState } from "react"
 
 export const TypeSlots = ({
@@ -39,7 +41,10 @@ export const TypeSlots = ({
     >
       <div className='mx-auto w-full max-w-4xl'>
         <RecordProvider target={quote}>
-          <Record target={quote} />
+          <div className={clsx("flex items-center justify-between")}>
+            <Record target={quote} />
+            <Progress current={index + 1} total={quotes.length} />
+          </div>
           <TypeArea
             ref={(element) => {
               typeAreaRefList.current[index] = element


### PR DESCRIPTION
<img width="942" alt="스크린샷 2024-10-19 오후 6 32 03" src="https://github.com/user-attachments/assets/6962cfe3-4f5a-4581-a27a-87559d6e3b6f">

타자를 진행 중, 현재 몇 번째까지 쳤고 얼마나 남았는지 짐작이 어려운 문제가 있어 우상단에 진행도 표시를 추가하였습니다.